### PR TITLE
Unable to call display.change_property

### DIFF
--- a/src/x11/display.cr
+++ b/src/x11/display.cr
@@ -2365,10 +2365,11 @@ module X11
     # `delete_property`, `window_property`, `properties`, `rotate_window_properties`.
     def change_property(w : X11::C::Window, property : Atom | X11::C::Atom, type : Atom | X11::C::Atom, mode : Int32, data : Bytes | Slice(Int16) | Slice(Int32)) : Int32
       format = case data
-      when Bytes then 8
-      when Slice(Int16) then 16
-      when Slice(Int32) then 32
+        in Bytes then 8
+        in Slice(Int16) then 16
+        in Slice(Int32) then 32
       end
+
       X.change_property @dpy, w, property.to_u64, type.to_u64, format, mode, data.to_unsafe, data.size
     end
 


### PR DESCRIPTION
Hello !

This PR follows #7. It just updates the declaration of `format` by using `case..in` instead of `case..when` to enforce type and prevent `TType | Nil`.