### PR TITLE
Fixes to calling display `put_image`

### DIFF
--- a/src/x11/display.cr
+++ b/src/x11/display.cr
@@ -5638,7 +5638,7 @@ module X11
     # `add_pixel`, `create_image`, `destroy_image`, `get_pixel`, `init_image`,
     # `put_pixel`, `get_sub_image`.
     def put_image(d : X11::C::Drawable, gc : X11::C::X::GC, image : Image, src_x : Int32, src_y : Int32, dest_x : Int32, dest_y : Int32, width : UInt32, height : UInt32) : Int32
-      X.put_image @dpy, d, gc, image.to_unsafe, src_x, xrc_y, dest_x, dest_y, width, height
+      X.put_image @dpy, d, gc, image.to_unsafe, src_x, src_y, dest_x, dest_y, width, height
     end
 
     # Returns the length of the event queue for the connected display. Note that

--- a/src/x11/image.cr
+++ b/src/x11/image.cr
@@ -35,5 +35,9 @@ module X11
     def finalize
       X.destroy_image @image
     end
+
+    def to_unsafe : X11::C::X::PImage
+      @image
+    end
   end
 end


### PR DESCRIPTION
Add a `to_unsafe` method for the Image class and fix typo for the `src_y` variable in `put_image`.