### PR TITLE
Fix GC routine for cleaning up an Image object

### DIFF
--- a/src/x11/image.cr
+++ b/src/x11/image.cr
@@ -33,7 +33,7 @@ module X11
     end
 
     def finalize
-      X.destroy_image @image
+      @image.value.f.destroy_image
     end
   end
 end


### PR DESCRIPTION
Just some context on how I ran into this bug, an exception would be raised `free(): invalid pointer`, when trying to create a new x11 image that would replace the previous set x11 image.

Trying to use the Xutils defined function [XDestroyImage](https://github.com/TamasSzekeres/x11-cr/blob/547a8d1f14ebbfdf3654eaf545e101e1d00acf9c/src/x11/c/Xutil.cr#L128), also resulted in a crash `free(): invalid pointer`.
