### PR TITLE
Add record extension

### DIFF
--- a/src/x11/c/Xlib.cr
+++ b/src/x11/c/Xlib.cr
@@ -3913,6 +3913,86 @@ module X11::C
       cookie : PGenericEventCookie
     ) : NoReturn
 
+
+    ### Record Extension (libXtst)
+
+    fun record_query_version = XRecordQueryVersion(
+      dpy : PDisplay,
+      major_version : Int32*,
+      minor_version : Int32*
+    ) : Status
+
+    fun record_alloc_range = XRecordAllocRange() : RecordRange*
+    struct RecordRange
+      core_requests : RecordRange8
+      core_replies : RecordRange8
+      ext_requests : RecordExtRange
+      ext_replies : RecordExtRange
+      delivered_events : RecordRange8
+      device_events : RecordRange8
+      errors : RecordRange8
+      client_started : Bool
+      client_died : Bool
+    end
+    struct RecordRange8
+      first : CChar
+      last : CChar
+    end
+    struct RecordRange16
+      first : UInt16
+      last : UInt16
+    end
+    struct RecordExtRange
+      ext_major : RecordRange8
+      ext_minor : RecordRange16
+    end
+    
+    enum RecordClientSpec
+      CurrentClients = 1
+      FutureClients
+      AllClients
+    end
+    
+    alias RecordContext = UInt64
+    fun record_create_context = XRecordCreateContext(
+      dpy : PDisplay,
+      flags : Int32,
+      clients : RecordClientSpec*,
+      n_clients : Int32,
+      ranges : RecordRange**,
+      n_ranges : Int32
+    ) : RecordContext
+    
+    fun record_enable_context_async = XRecordEnableContextAsync(
+      dpy : PDisplay,
+      context : RecordContext,
+      callback : RecordInterceptProc,
+      client_data : Void*
+    ) : Status
+    alias RecordInterceptProc = Void*, RecordInterceptData* ->
+    struct RecordInterceptData
+      id_base : XID
+      server_time : Time
+      client_seq : UInt64
+      category : Int32
+      client_swapped : Bool
+      data : Pointer
+      data_len : UInt64
+    end
+    
+    fun record_process_replies = XRecordProcessReplies(
+      dpy : PDisplay
+    ) : Void
+    
+    enum RecordInterceptDataCategory
+      FromServer
+      FromClient
+      ClientStarted
+      ClientDied
+      StartOfData
+      EndOfData
+    end
+
   end # lib Xlib
 
   X._Xdebug = 0

--- a/src/x11/record-extension.cr
+++ b/src/x11/record-extension.cr
@@ -1,0 +1,92 @@
+require "./c/Xlib"
+
+module X11
+  include C
+
+  # This is part of libXtst.
+  class RecordExtension
+    # The underlying Display object. Docs recommend using two separate
+    # connections for control and data.
+    getter ctrl_display = Display.new
+    # :ditto:
+    getter data_display = Display.new
+
+    # Connects to the display and raises if Record Extension Library was not found
+    # on the system.
+    def initialize
+      @ctrl_display.synchronize(true)
+      version = X.record_query_version(@ctrl_display.dpy, out _, out _)
+      raise "X Record Extension Library not installed. You probably need to install libXtst on your system." if version == 0
+    end
+
+    # Returns a new context.
+    # A *range* can be created with `create_range`.
+    #
+    # Example usage:
+    # ```
+	  # range = record.create_range
+	  # range.device_events.first = ::X11::KeyPress
+	  # range.device_events.last = ::X11::ButtonRelease
+	  # context = record.create_context(record_range)
+    # ```
+    def create_context(range : X::RecordRange, *, flags = 0, client_spec = X::RecordClientSpec::AllClients)
+      p_range = pointerof(range)
+      X.record_create_context(@ctrl_display.dpy, 0, pointerof(client_spec), 1, pointerof(p_range), 1)
+    end
+
+    # Create a mutable `range` for usage in `create_context`.
+    def create_range
+      ::X11::X.record_alloc_range.value
+    end
+
+    @async_callback_box : Pointer(Void)?
+    # Start listening for the events configured in `context.range`.
+    # This method does not block. The block does not get run on its own,
+    # you need to additionally repeatedly call `process_replies`.
+    # For the structure of `record_data.data`, please refer to xEvent (NOT XEvent)
+    # at `_xEvent` in `Xproto.h`. There are no docs available for this, only
+    # other reference implementations.
+    #
+    # Example usage:
+    # ```
+    # record.enable_context_async(context) do |record_data|
+    #   next if record_data.category != ::X11::X::RecordInterceptDataCategory::FromServer.value
+    #   xevent = record_data.data
+    #   repeat = xevent[2] == 1
+    #   next if repeat
+    #   type = xevent[0]
+    #   keycode = xevent[1]
+    #   state = xevent[28].unsafe_as(UInt8)
+    #   pp! type, keycode, state
+    # end
+		# fd = IO::FileDescriptor.new record.data_display.connection_number
+		# loop do
+		#   dpy_fd.wait_readable
+		#   record.process_replies
+		# end
+    # ```
+    def enable_context_async(context : X::RecordContext, &callback : X::RecordInterceptData ->)
+      boxed = Box.box(callback)
+      @async_callback_box = boxed
+      status = X.record_enable_context_async(@data_display.dpy, context, ->(closure_data, record_data) do
+        closure_as_callback = Box(typeof(callback)).unbox(closure_data)
+        closure_as_callback.call(record_data.value)
+      end, boxed)
+      raise "Could not enable record context" if status == 0
+    end
+
+    def process_replies
+      X.record_process_replies(@data_display.dpy)
+    end
+
+    def finalize
+      close
+    end
+
+    def close : Int32
+      res1 = @ctrl_display.close
+      res2 = @data_display.close
+      res1 == 0 ? res2 : res1
+    end
+  end
+end

--- a/src/x11/record-extension.cr
+++ b/src/x11/record-extension.cr
@@ -24,10 +24,10 @@ module X11
     #
     # Example usage:
     # ```
-	  # range = record.create_range
-	  # range.device_events.first = ::X11::KeyPress
-	  # range.device_events.last = ::X11::ButtonRelease
-	  # context = record.create_context(record_range)
+    # range = record.create_range
+    # range.device_events.first = ::X11::KeyPress
+    # range.device_events.last = ::X11::ButtonRelease
+    # context = record.create_context(record_range)
     # ```
     def create_context(range : X::RecordRange, *, flags = 0, client_spec = X::RecordClientSpec::AllClients)
       p_range = pointerof(range)
@@ -56,14 +56,14 @@ module X11
     #   next if repeat
     #   type = xevent[0]
     #   keycode = xevent[1]
-    #   state = xevent[28].unsafe_as(UInt8)
+    #   state = xevent[28]
     #   pp! type, keycode, state
     # end
-		# fd = IO::FileDescriptor.new record.data_display.connection_number
-		# loop do
-		#   dpy_fd.wait_readable
-		#   record.process_replies
-		# end
+    # fd = IO::FileDescriptor.new record.data_display.connection_number
+    # loop do
+    #   dpy_fd.wait_readable
+    #   record.process_replies
+    # end
     # ```
     def enable_context_async(context : X::RecordContext, &callback : X::RecordInterceptData ->)
       boxed = Box.box(callback)


### PR DESCRIPTION
Hello,

I [needed](https://github.com/phil294/AHK_X11/issues/1) bindings for [X Record Extension Library](https://www.x.org/releases/X11R7.6/doc/libXtst/recordlib.html) (recordlib, from `libxtst`), so I have implemented and tested parts of it (those that I need). Do you want this to extension become part of x11-cr too, or should it live separately? If you want it, I can also add the remaining functions at some point, either in this PR, or a separate one in a few weeks.

Not sure about the code style, class location, documentation and such... just tell me what you need / want changed. Feel free to edit around too of course.

Best