### PR TITLE
window_property: expose raw prop

### DIFF
--- a/src/x11/display.cr
+++ b/src/x11/display.cr
@@ -4689,15 +4689,14 @@ module X11
     #
     # ###See also
     # `change_property`, `delete_property`, `properties`, `rotate_window_properties`.
-    def window_property(w : X11::C::Window, property : Atom | X11::C::Atom, long_offset : Int64, long_length : Int64, delete : Bool, req_type : Atom | X11::C::Atom) : NamedTuple(actual_type: X11::C::Atom, actual_format: Int32, nitems: UInt64, bytes_after: UInt64, prop: String, res: Int32)
+    def window_property(w : X11::C::Window, property : Atom | X11::C::Atom, long_offset : Int64, long_length : Int64, delete : Bool, req_type : Atom | X11::C::Atom) : NamedTuple(actual_type: X11::C::Atom, actual_format: Int32, nitems: UInt64, bytes_after: UInt64, prop_string: String, prop: UInt8*, res: Int32)
       res = X.get_window_property @dpy, w, property.to_u64, long_offset, long_length, delete ? X::True : X::False, req_type.to_u64, out actual_type_return, out actual_format_return, out nitems_return, out bytes_after_return, out prop_return
       if prop_return.null?
         string = ""
       else
         string = String.new prop_return
-        X.free prop_return
       end
-      {actual_type: actual_type_return, actual_format: actual_format_return, nitems: nitems_return, bytes_after: bytes_after_return, prop: string, res: res}
+      {actual_type: actual_type_return, actual_format: actual_format_return, nitems: nitems_return, bytes_after: bytes_after_return, prop_string: string, prop: prop_return, res: res}
     end
 
     # Returns the specified window's attributes in the `WindowAttributes` structure.


### PR DESCRIPTION
Currently, `display.window_property(...)` always ever returns the property value as a String, but there seem to be cases where this is not right. For example, I'm working with `_NET_ACTIVE_WINDOW` https://specifications.freedesktop.org/wm-spec/latest/ar01s03.html#idm45374033238240 similar to this answer https://stackoverflow.com/a/73834445/3779853 and here the returned value is a `Window`, so a `UInt64`.

This I tried to just convert the returned String into a UInt64 but this is unreliable, probably because the 0-byte position is not predictable, if I understood this right. So unless I'm mistaken, the raw data needs to be exposed by this function too.

This is what I did in my PR. I **changed** the `prop` return value to `prop_string`. Then I could change the return value `prop` from `String` to `Char*` to better align with the overall naming convention of the file. So overall it's a breaking change. Tell me if you want me to change it.

Also, I have removed the `X.free prop_return` and I'm not quite sure about the implications of this :S

What I'm trying to say is, I guess, I don't really know what I am doing